### PR TITLE
feat: add membership-based loan policy service with auto late fee cal…

### DIFF
--- a/Library.Application/DTOs/BookLoanDtos.cs
+++ b/Library.Application/DTOs/BookLoanDtos.cs
@@ -40,3 +40,27 @@ public class RenewBookLoanDto
 {
     public int AdditionalDays { get; set; } = 14;
 }
+
+public class LoanEligibilityResultDto
+{
+    public bool IsEligible { get; set; }
+    public List<string> Reasons { get; set; } = [];
+    public int CurrentActiveLoans { get; set; }
+    public int MaxBooksAllowed { get; set; }
+    public int RemainingSlots { get; set; }
+    public int RecommendedLoanDurationDays { get; set; }
+    public decimal OutstandingFines { get; set; }
+    public decimal MaxOutstandingFinesAllowed { get; set; }
+}
+
+public class LateFeeCalculationDto
+{
+    public Guid LoanId { get; set; }
+    public DateTime DueDate { get; set; }
+    public DateTime ReturnDate { get; set; }
+    public int DaysLate { get; set; }
+    public decimal DailyRate { get; set; }
+    public decimal CalculatedFee { get; set; }
+    public bool WasCapped { get; set; }
+    public decimal MaxFee { get; set; }
+}

--- a/Library.Application/DependencyInjection.cs
+++ b/Library.Application/DependencyInjection.cs
@@ -14,6 +14,7 @@ public static class DependencyInjection
         services.AddScoped<ICustomerService, CustomerService>();
         services.AddScoped<IAuthorService, AuthorService>();
         services.AddScoped<IPublisherService, PublisherService>();
+        services.AddScoped<ILoanPolicyService, LoanPolicyService>();
         services.AddScoped<IBookLoanService, BookLoanService>();
         services.AddScoped<IBookReservationService, BookReservationService>();
         services.AddScoped<IFineService, FineService>();

--- a/Library.Application/Interfaces/IBookLoanService.cs
+++ b/Library.Application/Interfaces/IBookLoanService.cs
@@ -15,4 +15,6 @@ public interface IBookLoanService
     Task<BookLoanDto> ReturnBookAsync(Guid id, ReturnBookLoanDto returnDto);
     Task<BookLoanDto> RenewLoanAsync(Guid id, RenewBookLoanDto renewDto);
     Task DeleteAsync(Guid id);
+    Task<LoanEligibilityResultDto> CheckEligibilityAsync(Guid customerId);
+    Task<LateFeeCalculationDto> CalculateLateFeeAsync(Guid loanId);
 }

--- a/Library.Application/Interfaces/ILoanPolicyService.cs
+++ b/Library.Application/Interfaces/ILoanPolicyService.cs
@@ -1,0 +1,14 @@
+using Library.Domain.Enums;
+
+namespace Library.Application.Interfaces;
+
+public interface ILoanPolicyService
+{
+    int GetMaxLoanDurationDays(MembershipType membershipType);
+    int GetMaxBooksAllowed(MembershipType membershipType);
+    int GetMaxRenewals(MembershipType membershipType);
+    decimal GetDailyLateFeeRate(MembershipType membershipType);
+    decimal CalculateLateFee(DateTime dueDate, DateTime returnDate, MembershipType membershipType);
+    bool IsEligibleForLoan(bool isActive, DateTime? membershipExpiryDate, int activeLoans, MembershipType membershipType);
+    decimal GetMaxOutstandingFinesAllowed(MembershipType membershipType);
+}

--- a/Library.Application/Mappings/BookLoanMappings.cs
+++ b/Library.Application/Mappings/BookLoanMappings.cs
@@ -46,4 +46,22 @@ public static class BookLoanMappings
             CreatedAt = DateTime.UtcNow
         };
     }
+
+    public static BookLoan ToEntity(this CreateBookLoanDto dto, int loanDurationDays, int maxRenewals)
+    {
+        return new BookLoan
+        {
+            Id = Guid.NewGuid(),
+            BookId = dto.BookId,
+            CustomerId = dto.CustomerId,
+            ProcessedByUserId = dto.ProcessedByUserId,
+            LoanDate = DateTime.UtcNow,
+            DueDate = DateTime.UtcNow.AddDays(loanDurationDays),
+            Status = LoanStatus.Active,
+            Notes = dto.Notes,
+            RenewalCount = 0,
+            MaxRenewals = maxRenewals,
+            CreatedAt = DateTime.UtcNow
+        };
+    }
 }

--- a/Library.Application/Services/BookLoanService.cs
+++ b/Library.Application/Services/BookLoanService.cs
@@ -12,15 +12,21 @@ public class BookLoanService : IBookLoanService
     private readonly IBookLoanRepository _loanRepository;
     private readonly IBookRepository _bookRepository;
     private readonly ICustomerRepository _customerRepository;
+    private readonly IFineRepository _fineRepository;
+    private readonly ILoanPolicyService _loanPolicyService;
 
     public BookLoanService(
         IBookLoanRepository loanRepository,
         IBookRepository bookRepository,
-        ICustomerRepository customerRepository)
+        ICustomerRepository customerRepository,
+        IFineRepository fineRepository,
+        ILoanPolicyService loanPolicyService)
     {
         _loanRepository = loanRepository;
         _bookRepository = bookRepository;
         _customerRepository = customerRepository;
+        _fineRepository = fineRepository;
+        _loanPolicyService = loanPolicyService;
     }
 
     public async Task<BookLoanDto?> GetByIdAsync(Guid id)
@@ -70,14 +76,46 @@ public class BookLoanService : IBookLoanService
         var customer = await _customerRepository.GetByIdAsync(createDto.CustomerId)
             ?? throw new NotFoundException(nameof(Domain.Entities.Customer), createDto.CustomerId);
 
-        if (!customer.IsActive)
-            throw new BadRequestException("Customer membership is not active.");
+        // Check membership eligibility using policy service
+        var activeLoans = await _loanRepository.GetActiveLoanCountByCustomerAsync(createDto.CustomerId);
+        var maxBooks = _loanPolicyService.GetMaxBooksAllowed(customer.MembershipType);
 
-        var activeLoanCount = await _loanRepository.GetActiveLoanCountByCustomerAsync(createDto.CustomerId);
-        if (activeLoanCount >= customer.MaxBooksAllowed)
-            throw new BadRequestException($"Customer has reached the maximum loan limit of {customer.MaxBooksAllowed}.");
+        if (!_loanPolicyService.IsEligibleForLoan(
+                customer.IsActive,
+                customer.MembershipExpiryDate,
+                activeLoans,
+                customer.MembershipType))
+        {
+            if (!customer.IsActive)
+                throw new BadRequestException("Customer membership is not active.");
 
-        var loan = createDto.ToEntity();
+            if (customer.MembershipExpiryDate.HasValue && customer.MembershipExpiryDate.Value < DateTime.UtcNow)
+                throw new BadRequestException("Customer membership has expired.");
+
+            throw new BadRequestException($"Customer has reached the maximum loan limit of {maxBooks} for {customer.MembershipType} membership.");
+        }
+
+        // Check outstanding fines
+        var outstandingFines = await _fineRepository.GetTotalUnpaidFinesByCustomerAsync(createDto.CustomerId);
+        var maxFinesAllowed = _loanPolicyService.GetMaxOutstandingFinesAllowed(customer.MembershipType);
+        if (outstandingFines > maxFinesAllowed)
+            throw new BadRequestException(
+                $"Customer has outstanding fines of {outstandingFines:C} which exceeds the maximum allowed ({maxFinesAllowed:C}) for {customer.MembershipType} membership. Please pay fines before borrowing.");
+
+        // Check for duplicate active loan for the same book
+        var customerLoans = await _loanRepository.GetByCustomerIdAsync(createDto.CustomerId);
+        var hasActiveBookLoan = customerLoans.Any(l =>
+            l.BookId == createDto.BookId &&
+            (l.Status == LoanStatus.Active || l.Status == LoanStatus.Overdue));
+        if (hasActiveBookLoan)
+            throw new BadRequestException("Customer already has an active loan for this book.");
+
+        // Apply policy-based loan duration
+        var loanDuration = createDto.LoanDurationDays > 0
+            ? Math.Min(createDto.LoanDurationDays, _loanPolicyService.GetMaxLoanDurationDays(customer.MembershipType))
+            : _loanPolicyService.GetMaxLoanDurationDays(customer.MembershipType);
+
+        var loan = createDto.ToEntity(loanDuration, _loanPolicyService.GetMaxRenewals(customer.MembershipType));
         await _loanRepository.AddAsync(loan);
 
         book.AvailableCopies--;
@@ -96,10 +134,34 @@ public class BookLoanService : IBookLoanService
         if (loan.Status != LoanStatus.Active && loan.Status != LoanStatus.Overdue)
             throw new BadRequestException("This loan is not active.");
 
-        loan.ReturnDate = DateTime.UtcNow;
+        var returnDate = DateTime.UtcNow;
+        loan.ReturnDate = returnDate;
         loan.Status = LoanStatus.Returned;
         loan.Notes = returnDto.Notes;
-        loan.UpdatedAt = DateTime.UtcNow;
+        loan.UpdatedAt = returnDate;
+
+        // Auto-calculate and create late fee if overdue
+        var customer = await _customerRepository.GetByIdAsync(loan.CustomerId);
+        if (customer is not null && returnDate > loan.DueDate)
+        {
+            var lateFee = _loanPolicyService.CalculateLateFee(loan.DueDate, returnDate, customer.MembershipType);
+            if (lateFee > 0)
+            {
+                var daysLate = (int)Math.Ceiling((returnDate - loan.DueDate).TotalDays);
+                var fine = new Domain.Entities.Fine
+                {
+                    Id = Guid.NewGuid(),
+                    BookLoanId = loan.Id,
+                    CustomerId = loan.CustomerId,
+                    Amount = lateFee,
+                    Reason = $"Late return fee: {daysLate} day(s) overdue at {_loanPolicyService.GetDailyLateFeeRate(customer.MembershipType):C}/day",
+                    Status = FineStatus.Pending,
+                    CreatedAt = returnDate
+                };
+                await _fineRepository.AddAsync(fine);
+            }
+        }
+
         await _loanRepository.UpdateAsync(loan);
 
         var book = await _bookRepository.GetByIdAsync(loan.BookId);
@@ -121,15 +183,109 @@ public class BookLoanService : IBookLoanService
         if (loan.Status != LoanStatus.Active)
             throw new BadRequestException("Only active loans can be renewed.");
 
-        if (loan.RenewalCount >= loan.MaxRenewals)
-            throw new BadRequestException($"Maximum renewal limit ({loan.MaxRenewals}) reached.");
+        // Use policy-based max renewals
+        var customer = await _customerRepository.GetByIdAsync(loan.CustomerId);
+        var maxRenewals = customer is not null
+            ? _loanPolicyService.GetMaxRenewals(customer.MembershipType)
+            : loan.MaxRenewals;
 
-        loan.DueDate = loan.DueDate.AddDays(renewDto.AdditionalDays);
+        if (loan.RenewalCount >= maxRenewals)
+            throw new BadRequestException($"Maximum renewal limit ({maxRenewals}) reached for {customer?.MembershipType} membership.");
+
+        // Check outstanding fines before allowing renewal
+        if (customer is not null)
+        {
+            var outstandingFines = await _fineRepository.GetTotalUnpaidFinesByCustomerAsync(customer.Id);
+            var maxFinesAllowed = _loanPolicyService.GetMaxOutstandingFinesAllowed(customer.MembershipType);
+            if (outstandingFines > maxFinesAllowed)
+                throw new BadRequestException(
+                    $"Cannot renew: outstanding fines ({outstandingFines:C}) exceed the allowed limit ({maxFinesAllowed:C}). Please pay fines first.");
+        }
+
+        var maxDuration = customer is not null
+            ? _loanPolicyService.GetMaxLoanDurationDays(customer.MembershipType)
+            : 14;
+        var additionalDays = Math.Min(renewDto.AdditionalDays, maxDuration);
+
+        loan.DueDate = loan.DueDate.AddDays(additionalDays);
         loan.RenewalCount++;
+        loan.MaxRenewals = maxRenewals;
         loan.UpdatedAt = DateTime.UtcNow;
         await _loanRepository.UpdateAsync(loan);
 
         return loan.ToDto();
+    }
+
+    public async Task<LoanEligibilityResultDto> CheckEligibilityAsync(Guid customerId)
+    {
+        var customer = await _customerRepository.GetByIdAsync(customerId)
+            ?? throw new NotFoundException(nameof(Domain.Entities.Customer), customerId);
+
+        var activeLoans = await _loanRepository.GetActiveLoanCountByCustomerAsync(customerId);
+        var maxBooks = _loanPolicyService.GetMaxBooksAllowed(customer.MembershipType);
+        var outstandingFines = await _fineRepository.GetTotalUnpaidFinesByCustomerAsync(customerId);
+        var maxFines = _loanPolicyService.GetMaxOutstandingFinesAllowed(customer.MembershipType);
+        var isEligible = _loanPolicyService.IsEligibleForLoan(
+            customer.IsActive, customer.MembershipExpiryDate, activeLoans, customer.MembershipType);
+
+        var reasons = new List<string>();
+
+        if (!customer.IsActive)
+            reasons.Add("Customer membership is not active.");
+
+        if (customer.MembershipExpiryDate.HasValue && customer.MembershipExpiryDate.Value < DateTime.UtcNow)
+            reasons.Add($"Membership expired on {customer.MembershipExpiryDate.Value:yyyy-MM-dd}.");
+
+        if (activeLoans >= maxBooks)
+            reasons.Add($"Active loan limit reached ({activeLoans}/{maxBooks}).");
+
+        if (outstandingFines > maxFines)
+        {
+            reasons.Add($"Outstanding fines ({outstandingFines:C}) exceed the limit ({maxFines:C}).");
+            isEligible = false;
+        }
+
+        return new LoanEligibilityResultDto
+        {
+            IsEligible = isEligible,
+            Reasons = reasons,
+            CurrentActiveLoans = activeLoans,
+            MaxBooksAllowed = maxBooks,
+            RemainingSlots = Math.Max(0, maxBooks - activeLoans),
+            RecommendedLoanDurationDays = _loanPolicyService.GetMaxLoanDurationDays(customer.MembershipType),
+            OutstandingFines = outstandingFines,
+            MaxOutstandingFinesAllowed = maxFines
+        };
+    }
+
+    public async Task<LateFeeCalculationDto> CalculateLateFeeAsync(Guid loanId)
+    {
+        var loan = await _loanRepository.GetWithDetailsAsync(loanId)
+            ?? throw new NotFoundException(nameof(Domain.Entities.BookLoan), loanId);
+
+        var customer = await _customerRepository.GetByIdAsync(loan.CustomerId)
+            ?? throw new NotFoundException(nameof(Domain.Entities.Customer), loan.CustomerId);
+
+        var returnDate = loan.ReturnDate ?? DateTime.UtcNow;
+        var daysLate = returnDate > loan.DueDate
+            ? (int)Math.Ceiling((returnDate - loan.DueDate).TotalDays)
+            : 0;
+
+        var dailyRate = _loanPolicyService.GetDailyLateFeeRate(customer.MembershipType);
+        var rawFee = daysLate * dailyRate;
+        var calculatedFee = _loanPolicyService.CalculateLateFee(loan.DueDate, returnDate, customer.MembershipType);
+
+        return new LateFeeCalculationDto
+        {
+            LoanId = loanId,
+            DueDate = loan.DueDate,
+            ReturnDate = returnDate,
+            DaysLate = daysLate,
+            DailyRate = dailyRate,
+            CalculatedFee = calculatedFee,
+            WasCapped = rawFee > calculatedFee,
+            MaxFee = calculatedFee < rawFee ? calculatedFee : rawFee
+        };
     }
 
     public async Task DeleteAsync(Guid id)

--- a/Library.Application/Services/LoanPolicyService.cs
+++ b/Library.Application/Services/LoanPolicyService.cs
@@ -1,0 +1,113 @@
+using Library.Application.Interfaces;
+using Library.Domain.Enums;
+
+namespace Library.Application.Services;
+
+public class LoanPolicyService : ILoanPolicyService
+{
+    public int GetMaxLoanDurationDays(MembershipType membershipType)
+    {
+        return membershipType switch
+        {
+            MembershipType.Premium => 30,
+            MembershipType.Standard => 21,
+            MembershipType.Student => 28,
+            MembershipType.Senior => 28,
+            MembershipType.Basic => 14,
+            _ => 14
+        };
+    }
+
+    public int GetMaxBooksAllowed(MembershipType membershipType)
+    {
+        return membershipType switch
+        {
+            MembershipType.Premium => 10,
+            MembershipType.Standard => 7,
+            MembershipType.Student => 8,
+            MembershipType.Senior => 6,
+            MembershipType.Basic => 3,
+            _ => 3
+        };
+    }
+
+    public int GetMaxRenewals(MembershipType membershipType)
+    {
+        return membershipType switch
+        {
+            MembershipType.Premium => 5,
+            MembershipType.Standard => 3,
+            MembershipType.Student => 3,
+            MembershipType.Senior => 4,
+            MembershipType.Basic => 1,
+            _ => 1
+        };
+    }
+
+    public decimal GetDailyLateFeeRate(MembershipType membershipType)
+    {
+        return membershipType switch
+        {
+            MembershipType.Premium => 0.25m,
+            MembershipType.Standard => 0.50m,
+            MembershipType.Student => 0.15m,
+            MembershipType.Senior => 0.10m,
+            MembershipType.Basic => 0.75m,
+            _ => 0.75m
+        };
+    }
+
+    public decimal CalculateLateFee(DateTime dueDate, DateTime returnDate, MembershipType membershipType)
+    {
+        if (returnDate <= dueDate)
+            return 0m;
+
+        var daysLate = (int)Math.Ceiling((returnDate - dueDate).TotalDays);
+        var dailyRate = GetDailyLateFeeRate(membershipType);
+        var fee = daysLate * dailyRate;
+
+        var maxFee = GetMaxFee(membershipType);
+        return Math.Min(fee, maxFee);
+    }
+
+    public bool IsEligibleForLoan(bool isActive, DateTime? membershipExpiryDate, int activeLoans, MembershipType membershipType)
+    {
+        if (!isActive)
+            return false;
+
+        if (membershipExpiryDate.HasValue && membershipExpiryDate.Value < DateTime.UtcNow)
+            return false;
+
+        var maxBooks = GetMaxBooksAllowed(membershipType);
+        if (activeLoans >= maxBooks)
+            return false;
+
+        return true;
+    }
+
+    public decimal GetMaxOutstandingFinesAllowed(MembershipType membershipType)
+    {
+        return membershipType switch
+        {
+            MembershipType.Premium => 50.00m,
+            MembershipType.Standard => 25.00m,
+            MembershipType.Student => 15.00m,
+            MembershipType.Senior => 20.00m,
+            MembershipType.Basic => 10.00m,
+            _ => 10.00m
+        };
+    }
+
+    private static decimal GetMaxFee(MembershipType membershipType)
+    {
+        return membershipType switch
+        {
+            MembershipType.Premium => 15.00m,
+            MembershipType.Standard => 25.00m,
+            MembershipType.Student => 10.00m,
+            MembershipType.Senior => 10.00m,
+            MembershipType.Basic => 30.00m,
+            _ => 30.00m
+        };
+    }
+}

--- a/Library/Controllers/BookLoansController.cs
+++ b/Library/Controllers/BookLoansController.cs
@@ -101,6 +101,24 @@ public class BookLoansController : ControllerBase
         return Ok(loan);
     }
 
+    [HttpGet("eligibility/{customerId:guid}")]
+    [ProducesResponseType(typeof(LoanEligibilityResultDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<LoanEligibilityResultDto>> CheckEligibility(Guid customerId)
+    {
+        var result = await _loanService.CheckEligibilityAsync(customerId);
+        return Ok(result);
+    }
+
+    [HttpGet("{id:guid}/late-fee")]
+    [ProducesResponseType(typeof(LateFeeCalculationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<LateFeeCalculationDto>> CalculateLateFee(Guid id)
+    {
+        var result = await _loanService.CalculateLateFeeAsync(id);
+        return Ok(result);
+    }
+
     [HttpDelete("{id:guid}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]


### PR DESCRIPTION
Introduce LoanPolicyService that determines loan rules based on membership type:
- Max loan duration, max books, max renewals per membership tier
- Daily late fee rates with membership-specific caps
- Eligibility checks (active status, expiry, outstanding fines)

Enhanced BookLoanService with:
- Policy-driven loan creation with duplicate loan prevention
- Auto late fee generation on book return
- Outstanding fines check before loan/renewal
- New eligibility check and late fee calculation endpoints